### PR TITLE
Fixed parser issue - AdvancedTag has no attribute 'get'

### DIFF
--- a/AdvancedHTMLParser/Parser.py
+++ b/AdvancedHTMLParser/Parser.py
@@ -296,7 +296,7 @@ class AdvancedHTMLParser(HTMLParser):
 
         elements = []
 
-        if isFromRoot is True and root.get(attrName) == attrValue:
+        if isFromRoot is True and root.getAttribute(attrName) == attrValue:
             elements.append(root)
 
         for child in root.children:


### PR DESCRIPTION
## Issue
Parsing using `getElementsByAttr` fails due to wrong method `get` being called during parse

## Fix
Change `get` to `getAttribute`, as this is what I suspect was intended