### PR TITLE
README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 AdvancedHTMLParser
 ==================
 
-AdvancedHTMLParser is an Advanced HTML Parser, with support for adding, removing, modifying, and formatting HTML. 
+AdvancedHTMLParser is an Advanced HTML Parser, with support for adding, removing, modifying, and formatting HTML.
 
 It aims to provide the same interface as you would find in a compliant browser through javascript ( i.e. all the getElement methods, appendChild, etc), as well as many more complex and sophisticated features not available through a browser. And most importantly, it's in python!
 
@@ -157,7 +157,7 @@ It also exposes the various getElement\* functions which operate on the elements
 
 For example:
 
-	
+
 	# Filter off the parser all tags with "item" in class
 	tagCollection = document.getElementsByClassName('item')
 
@@ -219,7 +219,7 @@ some of these include:
 
 	getPeersByAttr          - Gets peers by an arbitrary attribute/value combination
 
-	getPeersWithAttrValues  - Gets peers by an arbitrary attribute/values combination. 
+	getPeersWithAttrValues  - Gets peers by an arbitrary attribute/values combination.
 
 	getPeersByClassName   - Gets peers that contain a given class name
 
@@ -414,7 +414,7 @@ InvalidAttributeNameException - An attribute name was found that contained an in
 IndexedAdvancedHTMLParser
 =========================
 
-IndexedAdvancedHTMLParser provides the ability to use indexing for faster search. If you are just parsing and not modifying, this is your best bet. If you are modifying the DOM tree, make sure you call IndexedAdvancedHTMLParser.reindex() before relying on them. 
+IndexedAdvancedHTMLParser provides the ability to use indexing for faster search. If you are just parsing and not modifying, this is your best bet. If you are modifying the DOM tree, make sure you call IndexedAdvancedHTMLParser.reindex() before relying on them.
 
 Each of the get\* functions above takes an additional "useIndex" function, which can also be set to False to skip index. See constructor for more information, and "Performance and Indexing" section below.
 
@@ -606,4 +606,3 @@ Unit Tests
 ----------
 
 See "tests" directory available in github. Use "runTests.py" within that directory. Tests use my [GoodTests](https://github.com/kata198/GoodTests) framework. It will download it to the current directory if not found in path, so you don't need to worry that it's a dependency.
-

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The AdvancedHTMLParser can read in a file (or string) of HTML, and will create a
 
 To populate an AdvancedHTMLParser from existing HTML:
 
+	import AdvancedHTMLParser
+
 	parser = AdvancedHTMLParser.AdvancedHTMLParser()
 
 	# Parse an HTML string into the document

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,8 @@ The AdvancedHTMLParser can read in a file (or string) of HTML, and will create a
 
 To populate an AdvancedHTMLParser from existing HTML:
 
+	import AdvancedHTMLParser
+
 	parser = AdvancedHTMLParser.AdvancedHTMLParser()
 
 	# Parse an HTML string into the document

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 AdvancedHTMLParser
 ==================
 
-AdvancedHTMLParser is an Advanced HTML Parser, with support for adding, removing, modifying, and formatting HTML. 
+AdvancedHTMLParser is an Advanced HTML Parser, with support for adding, removing, modifying, and formatting HTML.
 
 It aims to provide the same interface as you would find in a compliant browser through javascript ( i.e. all the getElement methods, appendChild, etc), as well as many more complex and sophisticated features not available through a browser. And most importantly, it's in python!
 
@@ -169,7 +169,7 @@ It also exposes the various getElement\* functions which operate on the elements
 
 For example:
 
-	
+
 	# Filter off the parser all tags with "item" in class
 
 	tagCollection = document.getElementsByClassName('item')
@@ -239,7 +239,7 @@ some of these include:
 
 	getPeersByAttr          \- Gets peers by an arbitrary attribute/value combination
 
-	getPeersWithAttrValues  \- Gets peers by an arbitrary attribute/values combination. 
+	getPeersWithAttrValues  \- Gets peers by an arbitrary attribute/values combination.
 
 	getPeersByClassName   \- Gets peers that contain a given class name
 
@@ -437,7 +437,7 @@ InvalidAttributeNameException - An attribute name was found that contained an in
 IndexedAdvancedHTMLParser
 =========================
 
-IndexedAdvancedHTMLParser provides the ability to use indexing for faster search. If you are just parsing and not modifying, this is your best bet. If you are modifying the DOM tree, make sure you call IndexedAdvancedHTMLParser.reindex() before relying on them. 
+IndexedAdvancedHTMLParser provides the ability to use indexing for faster search. If you are just parsing and not modifying, this is your best bet. If you are modifying the DOM tree, make sure you call IndexedAdvancedHTMLParser.reindex() before relying on them.
 
 Each of the get\* functions above takes an additional "useIndex" function, which can also be set to False to skip index. See constructor for more information, and "Performance and Indexing" section below.
 
@@ -641,5 +641,3 @@ Unit Tests
 ----------
 
 See "tests" directory available in github. Use "runTests.py" within that directory. Tests use my `GoodTests <https://github.com/kata198/GoodTests>`_ framework. It will download it to the current directory if not found in path, so you don't need to worry that it's a dependency.
-
-


### PR DESCRIPTION
Found myself searching around for correct import string which using "quickstart" example, though might be useful to other users to include. In doing so editor picked up some trivial whitespace stuff in README, thought might as well commit also.