### PR TITLE
Fix IndexedAdvancedHTMLParser.getElementById()

### DIFF
--- a/AdvancedHTMLParser/Parser.py
+++ b/AdvancedHTMLParser/Parser.py
@@ -1269,7 +1269,7 @@ class IndexedAdvancedHTMLParser(AdvancedHTMLParser):
         '''
         (root, isFromRoot) = self._handleRootArg(root)
 
-        if self.useIndex is True and self.indexIDs is True:
+        if useIndex is True and self.indexIDs is True:
 
             element = self._idMap.get(_id, None)
 


### PR DESCRIPTION
Fix the getElementById() method of IndexedAdvancedHTMLParser.

The original code produces the error:
`AttributeError: 'IndexedAdvancedHTMLParser' object has no attribute 'useIndex'`
