### PR TITLE
Fix comparison for Python3.8+

### DIFF
--- a/AdvancedHTMLParser/Formatter.py
+++ b/AdvancedHTMLParser/Formatter.py
@@ -175,7 +175,7 @@ class AdvancedHTMLFormatter(HTMLParser):
         else:
             raise MultipleRootNodeException()
 
-        if self.inPreformatted is 0:
+        if self.inPreformatted == 0:
             newTag._indent = self._getIndent()
 
         if tagName in PREFORMATTED_TAGS:
@@ -406,7 +406,7 @@ def handle_starttag_slim(self, tagName, attributeList, isSelfClosing=False):
     else:
         raise MultipleRootNodeException()
 
-    if self.inPreformatted is 0:
+    if self.inPreformatted == 0:
         newTag._indent = self._getIndent()
 
     if tagName in PREFORMATTED_TAGS:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+* 9.0.2 - Oct 28 2022
+
+- Fix comparisons with a literal using `is`.
+
 * 9.0.1 - Feb 12 2020
 
 - Fix installation issue under some conditions


### PR DESCRIPTION
Hi Tim, 

super small QoL change that'll remove some warnings popping up in newer Python versions. 
Formatter.py uses `is` for a comparison with a literal. In Python 3.8 and newer this causes a SyntaxWarning.
Change comparison with a literal to use `==` instad of `is`.
